### PR TITLE
TP-11151 changing the cookie strategy

### DIFF
--- a/.versions
+++ b/.versions
@@ -39,7 +39,7 @@ npm-mongo@3.8.1
 oauth@1.3.2
 oauth2@1.3.0
 ordered-dict@1.1.0
-pathable:imis-oauth@1.0.2
+pathable:imis-oauth@1.0.3
 promise@0.11.2
 random@1.2.0
 rate-limit@1.0.9

--- a/imis_client.js
+++ b/imis_client.js
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 
-const IMIS_CREDENTIALS = 'imisKey';
+const SCOPE = 'scope';
 
 Imis = {};
 
@@ -16,13 +16,20 @@ Imis.requestCredential = (options, credentialRequestCompleteCallback) => {
   const config = options.config;
   const credentialToken = Random.secret();
 
-  const loginStyle = 'redirect';
+  // An strange problem happen when defines the last key (imisKey) and back to the Pathable side
+  // it was overriding the SCOPE cookies, causing us to lose these cookies
+  // the solution below merge the current SCOPE cookie and adds the last data from cookie key (imisKey) to use the SCOPE key
+  // with this we won't lose the data and be able to complete the process
 
-  Cookies.set(IMIS_CREDENTIALS, JSON.stringify({ ...config, credentialToken }));
+  const currentCookie = JSON.parse(Cookies.get(SCOPE));
+
+  const newCookies = { ...currentCookie, ...config, credentialToken };
+
+  Cookies.set(SCOPE, JSON.stringify(newCookies));
 
   OAuth.launchLogin({
     loginService: 'imis',
-    loginStyle,
+    loginStyle: 'redirect',
     loginUrl: config.signInUrl,
     credentialRequestCompleteCallback,
     credentialToken,

--- a/imis_client.js
+++ b/imis_client.js
@@ -16,7 +16,7 @@ Imis.requestCredential = (options, credentialRequestCompleteCallback) => {
   const config = options.config;
   const credentialToken = Random.secret();
 
-  // An strange problem happen when defines the last key (imisKey) and back to the Pathable side
+  // A strange problem happen when defines the last key (imisKey) and back to the Pathable side
   // it was overriding the SCOPE cookies, causing us to lose these cookies
   // the solution below merge the current SCOPE cookie and adds the last data from cookie key (imisKey) to use the SCOPE key
   // with this we won't lose the data and be able to complete the process

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Imis OAuth flow',
-  version: '1.0.3',
+  version: '1.0.4',
   name: 'pathable:imis-oauth',
   git: 'https://github.com/pathable/imis-oauth',
 });


### PR DESCRIPTION
A strange problem happens when defines the last key (imisKey) and back to the Pathable side, it was overriding the SCOPE cookies, causing us to lose these cookies the solution below merge the current SCOPE cookie and adds the last data from the cookie key (imisKey) to use the SCOPE key, with this we won't lose the data and be able to complete the process.